### PR TITLE
Enable confirm button only after all ships are placed

### DIFF
--- a/battleship_cliente/src/main/java/com/itson/equipo2/battleship_cliente/controllers/PosicionarController.java
+++ b/battleship_cliente/src/main/java/com/itson/equipo2/battleship_cliente/controllers/PosicionarController.java
@@ -27,4 +27,8 @@ public class PosicionarController {
 
         return this.partidaModel.intentarPosicionarNavePropia(tipo, col, fila, esHorizontal);
     }
+    
+    public void confirmarPosicionamiento() {
+        
+    }
 }

--- a/battleship_cliente/src/main/java/com/itson/equipo2/battleship_cliente/service/PosicionarNaveService.java
+++ b/battleship_cliente/src/main/java/com/itson/equipo2/battleship_cliente/service/PosicionarNaveService.java
@@ -37,4 +37,8 @@ public class PosicionarNaveService {
 
         publisher.publish("battleship:comandos", message);
     }
+    
+    public void confirmarPosicionamiento() {
+        
+    }
 }

--- a/battleship_cliente/src/main/java/com/itson/equipo2/battleship_cliente/view/PosicionarNaveVista.form
+++ b/battleship_cliente/src/main/java/com/itson/equipo2/battleship_cliente/view/PosicionarNaveVista.form
@@ -123,6 +123,7 @@
         <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
           <Border info="null"/>
         </Property>
+        <Property name="enabled" type="boolean" value="false"/>
         <Property name="focusPainted" type="boolean" value="false"/>
       </Properties>
       <Events>
@@ -142,6 +143,10 @@
           <Dimension value="[57, 57]"/>
         </Property>
       </Properties>
+      <AccessibilityProperties>
+        <Property name="AccessibleContext.accessibleName" type="java.lang.String" value=""/>
+        <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" value=""/>
+      </AccessibilityProperties>
       <AuxValues>
         <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new SelectorNaveView(TipoNave.BARCO, this.tablero, this.posicionarController)"/>
       </AuxValues>

--- a/battleship_cliente/src/main/java/com/itson/equipo2/battleship_cliente/view/PosicionarNaveVista.java
+++ b/battleship_cliente/src/main/java/com/itson/equipo2/battleship_cliente/view/PosicionarNaveVista.java
@@ -78,6 +78,7 @@ public class PosicionarNaveVista extends javax.swing.JPanel implements ViewFacto
         btnConfirmar.setForeground(new Color(255, 255, 255));
         btnConfirmar.setText("Confirmar");
         btnConfirmar.setBorder(null);
+        btnConfirmar.setEnabled(false);
         btnConfirmar.setFocusPainted(false);
         btnConfirmar.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent evt) {
@@ -187,10 +188,20 @@ public class PosicionarNaveVista extends javax.swing.JPanel implements ViewFacto
                         .addGap(99, 99, 99)))
                 .addComponent(btnConfirmar, GroupLayout.PREFERRED_SIZE, 41, GroupLayout.PREFERRED_SIZE))
         );
+
+        nave1.getAccessibleContext().setAccessibleName("");
+        nave1.getAccessibleContext().setAccessibleDescription("");
     }// </editor-fold>//GEN-END:initComponents
 
     private void btnConfirmarActionPerformed(ActionEvent evt) {//GEN-FIRST:event_btnConfirmarActionPerformed
+        posicionarController.confirmarPosicionamiento();
 
+        // Deshabilita todo para que no pueda mover nada más
+        btnConfirmar.setEnabled(false);
+        nave1.setEnabled(false);
+        nave2.setEnabled(false);
+        nave3.setEnabled(false);
+        nave4.setEnabled(false);
     }//GEN-LAST:event_btnConfirmarActionPerformed
 
     @Override
@@ -225,6 +236,8 @@ public class PosicionarNaveVista extends javax.swing.JPanel implements ViewFacto
                 }
             }
         }
+        
+        actualizarEstadoBoton();
     }
 
     private void crearCeldas() {
@@ -242,6 +255,19 @@ public class PosicionarNaveVista extends javax.swing.JPanel implements ViewFacto
         }
     }
 
+    public void actualizarEstadoBoton() {
+
+        // ¡El truco! Hacemos un "cast" al JPanel genérico
+        // para tratarlo como lo que realmente es: un SelectorNaveView.
+        boolean todosPuestos
+                = ((SelectorNaveView) nave1).getBarcosRestantes() == 0
+                && ((SelectorNaveView) nave2).getBarcosRestantes() == 0
+                && ((SelectorNaveView) nave3).getBarcosRestantes() == 0
+                && ((SelectorNaveView) nave4).getBarcosRestantes() == 0;
+        // (Añade '&& ((SelectorNaveView) nave5).getBarcosRestantes() == 0' si tienes una quinta nave)
+
+        btnConfirmar.setEnabled(todosPuestos);
+    }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private JButton btnConfirmar;

--- a/battleship_cliente/src/main/java/com/itson/equipo2/battleship_cliente/view/util/SelectorNaveView.java
+++ b/battleship_cliente/src/main/java/com/itson/equipo2/battleship_cliente/view/util/SelectorNaveView.java
@@ -5,6 +5,7 @@
 package com.itson.equipo2.battleship_cliente.view.util;
 
 import com.itson.equipo2.battleship_cliente.controllers.PosicionarController;
+import com.itson.equipo2.battleship_cliente.view.PosicionarNaveVista;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Container;
@@ -35,7 +36,7 @@ public class SelectorNaveView extends JPanel {
     private final JLabel lblTitulo;
     private final JLabel lblCantidad;
     private final JPanel tablero;
-
+    
     private final PosicionarController posicionarController;
 
     public SelectorNaveView(TipoNave tipo, JPanel tablero, PosicionarController posicionarController) {
@@ -100,4 +101,9 @@ public class SelectorNaveView extends JPanel {
         barcosRestantes++;
         lblCantidad.setText("Disponibles: " + barcosRestantes);
     }
+
+    public int getBarcosRestantes() {
+        return barcosRestantes;
+    }
+
 }


### PR DESCRIPTION
Added logic to enable the 'Confirmar' button in PosicionarNaveVista only when all ships have been positioned. Disabled ship selectors and the confirm button after confirmation. Introduced getBarcosRestantes() in SelectorNaveView to support this check, and added placeholder confirmarPosicionamiento methods in controller and service layers.